### PR TITLE
Use API init timestamp for daily forecasts

### DIFF
--- a/eurorbit.html
+++ b/eurorbit.html
@@ -211,6 +211,61 @@
             tsrain: '⛈️'
         };
 
+        const MS_PER_HOUR = 60 * 60 * 1000;
+
+        function parseInitTimestamp(init) {
+            if (typeof init !== 'string' || init.length < 10) {
+                return new Date();
+            }
+
+            const year = Number(init.slice(0, 4));
+            const month = Number(init.slice(4, 6)) - 1;
+            const day = Number(init.slice(6, 8));
+            const hour = Number(init.slice(8, 10));
+
+            if ([year, month, day, hour].some(Number.isNaN)) {
+                return new Date();
+            }
+
+            return new Date(Date.UTC(year, month, day, hour));
+        }
+
+        function getDailyForecasts(dataseries, baseDate) {
+            const dayMap = new Map();
+
+            dataseries.forEach(entry => {
+                const forecastDate = new Date(baseDate.getTime() + entry.timepoint * MS_PER_HOUR);
+                const dayKey = forecastDate.toISOString().split('T')[0];
+                if (!dayMap.has(dayKey)) {
+                    dayMap.set(dayKey, []);
+                }
+                dayMap.get(dayKey).push({ data: entry, forecastDate });
+            });
+
+            const sortedDays = Array.from(dayMap.entries()).sort(
+                (a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime()
+            );
+
+            const dailyForecasts = [];
+            for (const [, entries] of sortedDays) {
+                entries.sort((a, b) => {
+                    const hourDiff = Math.abs(a.forecastDate.getUTCHours() - 12) -
+                        Math.abs(b.forecastDate.getUTCHours() - 12);
+                    if (hourDiff !== 0) {
+                        return hourDiff;
+                    }
+                    return a.forecastDate.getTime() - b.forecastDate.getTime();
+                });
+
+                dailyForecasts.push(entries[0]);
+                if (dailyForecasts.length === 7) {
+                    break;
+                }
+            }
+
+            return dailyForecasts;
+        }
+
         // Initialize the application
         document.addEventListener('DOMContentLoaded', () => {
             const citySelect = document.getElementById('city-select');
@@ -233,22 +288,22 @@
                     );
                     const data = await response.json();
 
+                    const baseDate = parseInitTimestamp(data.init);
+                    const dailyForecasts = getDailyForecasts(data.dataseries, baseDate);
+
                     // Display weather data
-                    selectedCityElement.textContent = 
+                    selectedCityElement.textContent =
                         cityName.charAt(0).toUpperCase() + cityName.slice(1);
-                    
+
                     // Clear previous forecast
                     forecastGrid.innerHTML = '';
 
                     // Display next 7 days forecast
-                    data.dataseries.slice(0, 7).forEach(day => {
-                        const date = new Date();
-                        date.setHours(date.getHours() + day.timepoint);
-                        
+                    dailyForecasts.forEach(({ data: day, forecastDate }) => {
                         const weatherItem = document.createElement('div');
                         weatherItem.className = 'weather-item';
                         weatherItem.innerHTML = `
-                            <div>${date.toLocaleDateString()}</div>
+                            <div>${forecastDate.toLocaleDateString()}</div>
                             <div style="font-size: 2rem;">${WEATHER_ICONS[day.weather] || '🌈'}</div>
                             <div>${day.temp2m}°C</div>
                             <div>Humidity: ${day.rh2m}%</div>

--- a/scripts.js
+++ b/scripts.js
@@ -26,6 +26,61 @@ const WEATHER_ICONS = {
     tsrain: '⛈️'
 };
 
+const MS_PER_HOUR = 60 * 60 * 1000;
+
+function parseInitTimestamp(init) {
+    if (typeof init !== 'string' || init.length < 10) {
+        return new Date();
+    }
+
+    const year = Number(init.slice(0, 4));
+    const month = Number(init.slice(4, 6)) - 1;
+    const day = Number(init.slice(6, 8));
+    const hour = Number(init.slice(8, 10));
+
+    if ([year, month, day, hour].some(Number.isNaN)) {
+        return new Date();
+    }
+
+    return new Date(Date.UTC(year, month, day, hour));
+}
+
+function getDailyForecasts(dataseries, baseDate) {
+    const dayMap = new Map();
+
+    dataseries.forEach(entry => {
+        const forecastDate = new Date(baseDate.getTime() + entry.timepoint * MS_PER_HOUR);
+        const dayKey = forecastDate.toISOString().split('T')[0];
+        if (!dayMap.has(dayKey)) {
+            dayMap.set(dayKey, []);
+        }
+        dayMap.get(dayKey).push({ data: entry, forecastDate });
+    });
+
+    const sortedDays = Array.from(dayMap.entries()).sort(
+        (a, b) => new Date(a[0]).getTime() - new Date(b[0]).getTime()
+    );
+
+    const dailyForecasts = [];
+    for (const [, entries] of sortedDays) {
+        entries.sort((a, b) => {
+            const hourDiff = Math.abs(a.forecastDate.getUTCHours() - 12) -
+                Math.abs(b.forecastDate.getUTCHours() - 12);
+            if (hourDiff !== 0) {
+                return hourDiff;
+            }
+            return a.forecastDate.getTime() - b.forecastDate.getTime();
+        });
+
+        dailyForecasts.push(entries[0]);
+        if (dailyForecasts.length === 7) {
+            break;
+        }
+    }
+
+    return dailyForecasts;
+}
+
 document.addEventListener('DOMContentLoaded', () => {
     const citySelect = document.getElementById('city-select');
     const weatherDisplay = document.getElementById('weather-display');
@@ -46,19 +101,19 @@ document.addEventListener('DOMContentLoaded', () => {
             );
             const data = await response.json();
 
+            const baseDate = parseInitTimestamp(data.init);
+            const dailyForecasts = getDailyForecasts(data.dataseries, baseDate);
+
             selectedCityElement.textContent =
                 cityName.charAt(0).toUpperCase() + cityName.slice(1);
-            
+
             forecastGrid.innerHTML = '';
 
-            data.dataseries.slice(0, 7).forEach(day => {
-                const date = new Date();
-                date.setHours(date.getHours() + day.timepoint);
-
+            dailyForecasts.forEach(({ data: day, forecastDate }) => {
                 const weatherItem = document.createElement('div');
                 weatherItem.className = 'weather-item';
                 weatherItem.innerHTML = `
-                    <div>${date.toLocaleDateString()}</div>
+                    <div>${forecastDate.toLocaleDateString()}</div>
                     <div style="font-size: 2rem;">${WEATHER_ICONS[day.weather] || '🌈'}</div>
                     <div>${day.temp2m}°C</div>
                     <div>Humidity: ${day.rh2m}%</div>


### PR DESCRIPTION
## Summary
- derive a forecast base date from the API `init` timestamp and reuse it when rendering the scripts-driven UI
- condense the API dataseries to seven calendar days, selecting the entry closest to midday for each day in both JavaScript implementations

## Testing
- npm test *(fails: missing package.json in this repository)*
- node --check scripts.js

------
https://chatgpt.com/codex/tasks/task_e_68ca8389a524832eb59c4a12ceaad56f